### PR TITLE
Fix: Checkout submodules in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Verify frontend files
         run: |


### PR DESCRIPTION
The GitHub Actions workflow was failing because the `Dockerfile` in the `aquapump-mvp-forge` directory was not found. This was happening because the directory is a submodule and its contents were not being checked out.

This commit updates the `actions/checkout` step in the `.github/workflows/main.yml` file to include the `submodules: 'recursive'` option. This ensures that the contents of the submodule are checked out, making the `Dockerfile` available for the build step.